### PR TITLE
Fixes loading fragments on www.bitdefender.com

### DIFF
--- a/_src-lp/scripts/scripts.js
+++ b/_src-lp/scripts/scripts.js
@@ -216,6 +216,15 @@ function loadDelayed() {
  */
 export async function loadFragment(path) {
   if (path && path.startsWith('/')) {
+    /**
+     * this makes fragments work on the www.bitdefender.com domain
+     * once we move everything to www, we sghould remove this
+     */
+    if (window.location.hostname === 'wwww.bitdefender.com') {
+      // eslint-disable-next-line no-param-reassign
+      path = `/pages${path}`;
+    }
+
     const resp = await fetch(`${path}.plain.html`);
     if (resp.ok) {
       const main = document.createElement('main');


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://fragments--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
