### PR TITLE
DEX-15891 - fixed lib-franklin script path for 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -11,7 +11,7 @@
   <meta property="og:title" content="Page not found">
   <script src="/_src-lp/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
   <script type="module">
-    import { sampleRUM } from '/scripts/lib-franklin.js';
+    import { sampleRUM } from '/_src-lp/scripts/lib-franklin.js';
 
     window.addEventListener('load', () => {
       if (document.referrer) {


### PR DESCRIPTION
Fix #DEX-15891

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://dex-15891--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
