### PR TITLE
fixed sendAnalyticsPageEvent for all environments

### DIFF
--- a/_src-lp/scripts/adobeDataLayer.js
+++ b/_src-lp/scripts/adobeDataLayer.js
@@ -13,7 +13,7 @@ const formatNumber = (num) => String(num).padStart(2, '0');
 function getPageNameAndSections() {
   const DEFAULT_LANGUAGE = getDefaultLanguage();
 
-  const pageSectionParts = window.location.pathname.split('/').filter((subPath) => subPath !== '');
+  const pageSectionParts = window.location.pathname.split('/').filter((subPath) => subPath !== '' && subPath !== 'pages');
   const subSubSection = pageSectionParts[0];
 
   pageSectionParts[0] = DEFAULT_LANGUAGE === 'en' ? 'us' : DEFAULT_LANGUAGE;

--- a/jest/__tests__/adobeDatalayer.spec.js
+++ b/jest/__tests__/adobeDatalayer.spec.js
@@ -1,0 +1,40 @@
+import {sendAnalyticsPageEvent} from "../../_src-lp/scripts/adobeDataLayer";
+
+describe('adobeDatalayer.js', () => {
+  describe('sendAnalyticsPageEvent function', () => {
+    beforeEach(() => {
+      window.adobeDataLayer = [];
+      window = Object.create(window);
+      Object.defineProperty(window, 'location', {
+        value: {
+          host: '',
+          hostname: '',
+          pathname: ''
+        },
+        writable: true
+      });
+    });
+
+    it('should create the correct page.info.name for bitdefender.com/pages environment', async () => {
+      window.location.host = 'www.bitdefender.com';
+      window.location.hostname = 'www.bitdefender.com';
+      window.location.pathname = '/pages/consumer/en/new/new-campaign';
+
+      await sendAnalyticsPageEvent();
+      const [pageLoadStartedEvent] = window.adobeDataLayer;
+
+      expect(pageLoadStartedEvent.page.info.name).toBe('us:offers:consumer:new:new-campaign');
+    });
+
+    it('should create the correct page.info.name for pages.bitdefender.com environment', async () => {
+      window.location.host = 'pages.bitdefender.com';
+      window.location.hostname = 'pages.bitdefender.com';
+      window.location.pathname = '/consumer/en/new/new-campaign';
+
+      await sendAnalyticsPageEvent();
+      const [pageLoadStartedEvent] = window.adobeDataLayer;
+
+      expect(pageLoadStartedEvent.page.info.name).toBe('us:offers:consumer:new:new-campaign');
+    });
+  });
+});


### PR DESCRIPTION
Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://fix-adobe-datalayer--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
