### PR TITLE
feat: limit the time sentry loads to 1% of the visitors

### DIFF
--- a/.github/workflows/update-description.yaml
+++ b/.github/workflows/update-description.yaml
@@ -1,0 +1,21 @@
+name: Update PR Description Test URLs
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  track_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update PR Description
+        run: |
+          PR_UPDATED_BODY="$(
+            gh api /repos/$OWNER/$REPO/pulls/$PR_NUMBER | jq -r '.body' | sed 's/<branch>/${{github.ref_name}}/g'
+          )"
+          gh api --method PATCH /repos/$OWNER/$REPO/pulls/$PR_NUMBER -f body="$PR_UPDATED_BODY"
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOOSTED_MOD_PERSONAL_TOKEN_CLASSIC }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.number }}

--- a/_src-lp/scripts/delayed.js
+++ b/_src-lp/scripts/delayed.js
@@ -3,7 +3,9 @@ import { sampleRUM } from './lib-franklin.js';
 import { getInstance, addScript } from './utils.js';
 
 if (getInstance() === 'prod') {
-  addScript('https://js.sentry-cdn.com/31155ca43cab4235b06e5da92992eef0.min.js');
+  if ((Math.random() * 100) < 1) {
+    addScript('https://js.sentry-cdn.com/31155ca43cab4235b06e5da92992eef0.min.js');
+  }
 }
 
 // Core Web Vitals RUM collection


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [x] I have updated the sidekick documentation.
- [x] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://optimise--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
