### PR TITLE
feat: add logic to skip the update of VATinfo

### DIFF
--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -1,4 +1,4 @@
-import { getMetadata } from "./lib-franklin.js";
+import { getMetadata } from './lib-franklin.js';
 
 export const IANA_BY_REGION_MAP = new Map([
   [3, { locale: 'en-GB', label: 'united kingdom' }],

--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -1,3 +1,5 @@
+import { getMetadata } from "./lib-franklin.js";
+
 export const IANA_BY_REGION_MAP = new Map([
   [3, { locale: 'en-GB', label: 'united kingdom' }],
   [4, { locale: 'au-AU', label: 'australia' }],
@@ -267,8 +269,10 @@ export function showLoaderSpinner(showSpinner = true, pid = null) {
 
 // DEX-17703 - replacing VAT INFO text for en regions
 export function updateVATinfo(countryCode, selector) {
-  const prodloadElements = document.querySelectorAll(selector);
+  const skipVATinfo = getMetadata('skip-vatinfo-logic');
+  if (skipVATinfo && skipVATinfo === 'true') return;
 
+  const prodloadElements = document.querySelectorAll(selector);
   prodloadElements.forEach((element) => {
     const prodloadElement = element.closest('[data-testid="prod_box"]') || element.closest('.prices_box') || element.closest('.prod_box') || element.closest('.hasProds');
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [x] I have updated the sidekick documentation.
- [x] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://update-taxestext--www-landing-pages--bitdefender.hlx.page/drafts/test-page/