### PR TITLE
fix: don't use cache for prices

### DIFF
--- a/_src-lp/scripts/scripts.js
+++ b/_src-lp/scripts/scripts.js
@@ -883,7 +883,7 @@ function initSelectors(pid) {
         selected_years: prodYears,
         users_class: `users_${onSelectorClass}_fake`,
         years_class: `years_${onSelectorClass}_fake`,
-        method: 'GET',
+        method: 'POST',
 
         ...(pid === 'ignore' ? { ignore_promotions: true } : {}),
         ...(pid !== false && pid !== 'ignore' ? { extra_params: { pid } } : {}),


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://cache--www-landing-pages--bitdefender.hlx.page/drafts/test-page/