### PR TITLE
fix: missing bundle id for new product

### DIFF
--- a/_src-lp/scripts/vendor/product.js
+++ b/_src-lp/scripts/vendor/product.js
@@ -47,7 +47,8 @@ export default class ProductPrice {
     us_pie: "com.bitdefender.ultimatesecurityplusus.v2",
     us_pie_m: "com.bitdefender.ultimatesecurityplusus.v2",
     us_pfe: "com.bitdefender.ultimatesecurityplusus.v2",
-    us_pfe_m: "com.bitdefender.ultimatesecurityplusus.v2"
+    us_pfe_m: "com.bitdefender.ultimatesecurityplusus.v2",
+    avpm: "com.bitdefender.cl.avplus.v2",
   }
 
   #locale;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://fix--www-landing-pages--bitdefender.hlx.page/drafts/test-page/