### PR TITLE
fix: dropdown arrow overlapping text

### DIFF
--- a/_src-lp/blocks/features/features.css
+++ b/_src-lp/blocks/features/features.css
@@ -48,8 +48,6 @@
   content: "❯";
   font-weight: bold;
   position: absolute;
-  top: 0;
-  right: -15px;
   margin-left: 8px;
   transition: transform 0.4s;
   transform: rotate(90deg);

--- a/_src-lp/blocks/features/features.css
+++ b/_src-lp/blocks/features/features.css
@@ -41,6 +41,7 @@
   position: relative;
   cursor: pointer;
   margin-bottom: 5px;
+  width: 95%;
 }
 
 .features-container .features .feature-list .accordion::after {
@@ -48,6 +49,7 @@
   font-weight: bold;
   position: absolute;
   top: 0;
+  right: -15px;
   margin-left: 8px;
   transition: transform 0.4s;
   transform: rotate(90deg);

--- a/_src-lp/blocks/features/features.scss
+++ b/_src-lp/blocks/features/features.scss
@@ -48,8 +48,6 @@
   content: '\276F';
   font-weight: bold;
   position: absolute;
-  top: 0;
-  right: -15px;
   margin-left: 8px;
   transition: transform 0.4s;
   transform: rotate(90deg);

--- a/_src-lp/blocks/features/features.scss
+++ b/_src-lp/blocks/features/features.scss
@@ -41,6 +41,7 @@
   position: relative;
   cursor: pointer;
   margin-bottom: 5px;
+  width: 95%;
 }
 
 .features-container .features .feature-list .accordion::after {
@@ -48,6 +49,7 @@
   font-weight: bold;
   position: absolute;
   top: 0;
+  right: -15px;
   margin-left: 8px;
   transition: transform 0.4s;
   transform: rotate(90deg);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://dex-21278--www-landing-pages--bitdefender.hlx.page/drafts/test-page/