### PR TITLE
DEX-22021 fix: elements not fully visible in b-single-quote block

### DIFF
--- a/_src-lp/blocks/b-single-quote/b-single-quote.css
+++ b/_src-lp/blocks/b-single-quote/b-single-quote.css
@@ -51,7 +51,10 @@
 
 @media screen and (width >= 992px) {
   .b-single-quote-container .main-wrapper {
-    height: 550px;
+    z-index: 0;
+    min-height: 550px;
+    height: 100%;
+    align-content: center;
   }
   .b-single-quote-container .main-wrapper::before {
     content: "";
@@ -62,14 +65,14 @@
     width: 57.4%;
     height: 169%;
     border-radius: 0 50% 50% 0;
-    z-index: 1;
+    z-index: -998;
   }
   .b-single-quote-container .main-wrapper .inner-wrapper {
     width: 100%;
     height: 100%;
-    position: absolute;
-    z-index: 1;
+    z-index: 2;
     color: white;
+    align-self: center;
   }
   .b-single-quote-container .main-wrapper .inner-wrapper .container {
     display: flex;
@@ -81,6 +84,10 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    top: 0;
+    right: 0;
+    position: absolute;
+    z-index: -999;
   }
   .b-single-quote-container .main-wrapper q {
     display: block;

--- a/_src-lp/blocks/b-single-quote/b-single-quote.scss
+++ b/_src-lp/blocks/b-single-quote/b-single-quote.scss
@@ -51,7 +51,10 @@
 
 @media screen and (width >= 992px) {
   .b-single-quote-container .main-wrapper {
-    height: 550px;
+    z-index: 0;
+    min-height: 550px;
+    height: 100%;
+    align-content: center;
   }
 
   .b-single-quote-container .main-wrapper::before {
@@ -63,15 +66,15 @@
     width: 57.4%;
     height: 169%;
     border-radius: 0 50% 50% 0;
-    z-index: 1;
+    z-index: -998;
   }
 
   .b-single-quote-container .main-wrapper .inner-wrapper {
     width: 100%;
     height: 100%;
-    position: absolute;
-    z-index: 1;
+    z-index: 2;
     color: white;
+    align-self: center;
   }
 
   .b-single-quote-container .main-wrapper .inner-wrapper .container {
@@ -85,6 +88,10 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    top: 0;
+    right: 0;
+    position: absolute;
+    z-index: -999;
   }
 
   .b-single-quote-container .main-wrapper q {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
- After: https://dex-22021--www-landing-pages--bitdefender.hlx.page/drafts/test-page/
