### PR TITLE
Adding page target before adobe_mc

### DIFF
--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -201,7 +201,7 @@ export function appendAdobeMcLinks(selector) {
     const wrapperSelector = document.querySelector(selector);
     const hrefSelector = '[href*=".bitdefender."]';
     wrapperSelector.querySelectorAll(hrefSelector).forEach(async (link) => {
-      const [ linkHref, linkTarget ] = link.href.split('#');
+      const [linkHref, linkTarget] = link.href.split('#');
       const isAdobeMcAlreadyAdded = linkHref.includes('adobe_mc');
       if (isAdobeMcAlreadyAdded) {
         return;

--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -201,12 +201,14 @@ export function appendAdobeMcLinks(selector) {
     const wrapperSelector = document.querySelector(selector);
     const hrefSelector = '[href*=".bitdefender."]';
     wrapperSelector.querySelectorAll(hrefSelector).forEach(async (link) => {
-      const isAdobeMcAlreadyAdded = link.href.includes('adobe_mc');
+      const [ linkHref, linkTarget ] = link.href.split('#');
+      const isAdobeMcAlreadyAdded = linkHref.includes('adobe_mc');
       if (isAdobeMcAlreadyAdded) {
         return;
       }
 
-      const destinationURLWithVisitorIDs = await Target.appendVisitorIDsTo(link.href);
+      let destinationURLWithVisitorIDs = await Target.appendVisitorIDsTo(linkHref);
+      if (linkTarget) destinationURLWithVisitorIDs = destinationURLWithVisitorIDs.replace('?', `#${linkTarget}?`);
       link.href = destinationURLWithVisitorIDs.replace(/MCAID%3D.*%7CMCORGID/, 'MCAID%3D%7CMCORGID');
     });
   } catch (e) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [x] I have updated the sidekick documentation.
- [x] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://DEX-19772-v2--www-landing-pages--bitdefender.aem.page/drafts/test-page/
