### PR TITLE
undo adobe_mc has page target

### DIFF
--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -196,14 +196,12 @@ export function appendAdobeMcLinks(selector) {
     const wrapperSelector = document.querySelector(selector);
     const hrefSelector = '[href*=".bitdefender."]';
     wrapperSelector.querySelectorAll(hrefSelector).forEach(async (link) => {
-      const [linkHref, linkTarget] = link.href.split('#');
-      const isAdobeMcAlreadyAdded = linkHref.includes('adobe_mc');
+      const isAdobeMcAlreadyAdded = link.href.includes('adobe_mc');
       if (isAdobeMcAlreadyAdded) {
         return;
       }
 
-      let destinationURLWithVisitorIDs = await target.appendVisitorIDsTo(link.href);
-      if (linkTarget) destinationURLWithVisitorIDs = destinationURLWithVisitorIDs.replace('?', `#${linkTarget}?`);
+      const destinationURLWithVisitorIDs = await Target.appendVisitorIDsTo(link.href);
       link.href = destinationURLWithVisitorIDs.replace(/MCAID%3D.*%7CMCORGID/, 'MCAID%3D%7CMCORGID');
     });
   } catch (e) {

--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -1,4 +1,4 @@
-import { target, getDefaultLanguage } from './target.js';
+import { Target, adobeMcAppendVisitorId, getDefaultLanguage } from './target.js';
 import { getMetadata } from './lib-franklin.js';
 import { Bundle } from './vendor/product.js';
 
@@ -195,7 +195,9 @@ export function appendAdobeMcLinks(selector) {
   try {
     const wrapperSelector = document.querySelector(selector);
     const hrefSelector = '[href*=".bitdefender."]';
+
     wrapperSelector.querySelectorAll(hrefSelector).forEach(async (link) => {
+      console.log('link ', link)
       const isAdobeMcAlreadyAdded = link.href.includes('adobe_mc');
       if (isAdobeMcAlreadyAdded) {
         return;

--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -199,13 +199,13 @@ export function appendAdobeMcLinks(selector) {
     const hrefSelector = '[href*=".bitdefender."]';
 
     wrapperSelector.querySelectorAll(hrefSelector).forEach(async (link) => {
-      console.log('link ', link)
+      if (link.href.includes('#')) return;
       const isAdobeMcAlreadyAdded = link.href.includes('adobe_mc');
       if (isAdobeMcAlreadyAdded) {
         return;
       }
 
-      const destinationURLWithVisitorIDs = await Target.appendVisitorIDsTo(link.href);
+      const destinationURLWithVisitorIDs = await target.appendVisitorIDsTo(link.href);
       link.href = destinationURLWithVisitorIDs.replace(/MCAID%3D.*%7CMCORGID/, 'MCAID%3D%7CMCORGID');
     });
   } catch (e) {

--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -199,7 +199,6 @@ export function appendAdobeMcLinks(selector) {
     const hrefSelector = '[href*=".bitdefender."]';
 
     wrapperSelector.querySelectorAll(hrefSelector).forEach(async (link) => {
-      if (link.href.includes('#')) return;
       const isAdobeMcAlreadyAdded = link.href.includes('adobe_mc');
       if (isAdobeMcAlreadyAdded) {
         return;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://dex-19772-v3--www-landing-pages--bitdefender.aem.page/drafts/test-page/