### PR TITLE
DEX-23995 - move setTrialLinks from delayed to lazyLoad

### DIFF
--- a/_src-lp/scripts/delayed.js
+++ b/_src-lp/scripts/delayed.js
@@ -1,11 +1,8 @@
 // eslint-disable-next-line import/no-cycle
-import { sampleRUM, getMetadata } from './lib-franklin.js';
-import { fetchGeoIP, setTrialLinks } from './utils.js';
+import { sampleRUM } from './lib-franklin.js';
+import { fetchGeoIP } from './utils.js';
 
 fetchGeoIP();
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
-
-const trialLinkValue = getMetadata('trialbuylinks');
-if (trialLinkValue) setTrialLinks();

--- a/_src-lp/scripts/scripts.js
+++ b/_src-lp/scripts/scripts.js
@@ -36,6 +36,7 @@ import {
   adobeMcAppendVisitorId,
   formatPrice,
   getInstance,
+  setTrialLinks,
 } from './utils.js';
 
 const page = await pagePromise;
@@ -290,9 +291,9 @@ export async function loadLazy(doc) {
   adobeMcAppendVisitorId('main');
   go2Anchor();
 
-  if (getMetadata('free-product')) {
-    sendTrialDownloadedEvent();
-  }
+  if (getMetadata('free-product')) sendTrialDownloadedEvent();
+  if (getMetadata('trialbuylinks')) setTrialLinks();
+
   // Get the visitorId when you need it.
   // await fpPromise
   //   .then((fp) => fp.get())


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://DEX-23995-v2--www-landing-pages--bitdefender.aem.page/drafts/test-page/