### PR TITLE
DEX-24101 - Missing parameters on buy buttons

### DIFF
--- a/_src-lp/blocks/new-prod-boxes/new-prod-boxes.js
+++ b/_src-lp/blocks/new-prod-boxes/new-prod-boxes.js
@@ -438,7 +438,7 @@ export default function decorate(block) {
               </div>` : billed.innerText}
 
               ${replaceBuyLinks ? `<div class="buy-btn">
-                <a class="red-buy-button buylink2-${selectorClass}" href="${buyLinkObj.href || '#'}"  title="Bitdefender">
+                <a class="red-buy-button buylink-${selectorClass}" href="#" data-href="${buyLinkObj.href}"  title="Bitdefender">
                   ${buyLinkObj.text.includes('0%') ? buyLinkObj.text.replace('0%', `<span class="percent-${onSelectorClass}"></span>`) : buyLinkObj.text}
                 </a>
               </div>` : `<div class="buy-btn">

--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -971,12 +971,14 @@ export async function showPrices(storeObj, triggerVPN = false, checkboxId = '', 
       parentDiv.querySelector(`.buylink-${onSelectorClass}`).href = buyLink;
       if (comparativeTextBox) {
         allBuyLinkBox.forEach((item) => {
-          item.href = buyLink;
+          item.href = item.getAttribute('data-href') || buyLink;
+          item.removeAttribute('data-href');
         });
       }
     } else {
       allBuyLinkBox.forEach((item) => {
-        item.href = buyLink;
+        item.href = item.getAttribute('data-href') || buyLink;
+        item.removeAttribute('data-href');
       });
     }
   }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [x] I have updated the sidekick documentation.
- [x] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://DEX-24101--www-landing-pages--bitdefender.aem.page/drafts/test-page/
