### PR TITLE
DEX-24808  - small fix - remobe margin top on 1st button

### DIFF
--- a/_src-lp/scripts/template-factories/creators/creators.css
+++ b/_src-lp/scripts/template-factories/creators/creators.css
@@ -82,7 +82,7 @@ main .section.pb-0 {
   font-weight: 600;
   text-align: center;
   transition: all 0.3s ease;
-  margin: 10px 10px 10px 0;
+  margin: 0 10px 10px 0;
 }
 
 .creators .has-trial-btn p.button-container a:hover {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [x] I have updated the sidekick documentation.
- [x] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://DEX-24808-fix--www-landing-pages--bitdefender.aem.page/drafts/test-page/