### PR TITLE
Fix trial coupon - get the coupon from param or metadata before getting it from old url

### DIFF
--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -618,11 +618,11 @@ export async function setTrialLinks(onSelector = undefined, storeObjBuyLink = un
       }
     }));
   } else {
-    let [productId, prodUsers, prodYears] = onSelector.split('/');
+    const [productId, prodUsers, prodYears] = onSelector.split('/');
     const onSelectorClass = `${productId}-${prodUsers}${prodYears}`;
 
     const prodYearsInt = parseInt(prodYears, 10);
-    prodYears = (prodYearsInt >= 1 && prodYearsInt <= 3)
+    const prodYearsConv = (prodYearsInt >= 1 && prodYearsInt <= 3)
       ? prodYearsInt * 12
       : prodYearsInt;
 
@@ -635,7 +635,7 @@ export async function setTrialLinks(onSelector = undefined, storeObjBuyLink = un
 
     if (match) {
       const oldUrl = storeObjBuyLink;
-      const updatedUrl = await buildUpdatedUrl(oldUrl, match.buy_link, productId, prodUsers, prodYears);
+      const updatedUrl = await buildUpdatedUrl(oldUrl, match.buy_link, productId, prodUsers, prodYearsConv);
       document.querySelectorAll(`.buylink-${onSelectorClass}:not(.no-trial)`).forEach((link) => link.setAttribute('href', updatedUrl));
     }
   }

--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -531,11 +531,7 @@ export async function setTrialLinks(onSelector = undefined, storeObjBuyLink = un
     const oldParams = new URL(oldUrl).searchParams;
     let campaign = page.getParamValue('vcampaign') || getMetadata('vcampaign') || oldParams.get('COUPON');
 
-
-    if (['de', 'nl', 'au', 'gb'].includes(page.country)) {
-      campaign = await fetchProductInfo(productId, prodUsers, prodYears, 'coupon');
-    }
-
+    if (['de', 'nl', 'au', 'gb'].includes(page.country)) campaign = await fetchProductInfo(productId, prodUsers, prodYears, 'coupon');
     const updatedUrl = new URL(newUrl);
     const newParams = updatedUrl.searchParams;
 
@@ -622,8 +618,14 @@ export async function setTrialLinks(onSelector = undefined, storeObjBuyLink = un
       }
     }));
   } else {
-    const [productId, prodUsers, prodYears] = onSelector.split('/');
+    let [productId, prodUsers, prodYears] = onSelector.split('/');
     const onSelectorClass = `${productId}-${prodUsers}${prodYears}`;
+
+    const prodYearsInt = parseInt(prodYears, 10);
+    prodYears = (prodYearsInt >= 1 && prodYearsInt <= 3)
+      ? prodYearsInt * 12
+      : prodYearsInt;
+
     const match = trialLinks.find((item) => (
       item.locale.toLowerCase() === locale
       && item.product === productId

--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -529,7 +529,8 @@ export async function setTrialLinks(onSelector = undefined, storeObjBuyLink = un
   const buildUpdatedUrl = async (oldUrl, newUrl, productId, prodUsers, prodYears) => {
     const locale = page.country;
     const oldParams = new URL(oldUrl).searchParams;
-    let campaign = oldParams.get('COUPON');
+    let campaign = page.getParamValue('vcampaign') || getMetadata('vcampaign') || oldParams.get('COUPON');
+
 
     if (['de', 'nl', 'au', 'gb'].includes(page.country)) {
       campaign = await fetchProductInfo(productId, prodUsers, prodYears, 'coupon');


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [x] I have updated the sidekick documentation.
- [x] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://fix-trial-coupon--www-landing-pages--bitdefender.aem.page/drafts/test-page/
