### PR TITLE
Undo - coupon can only be taken from old buy link

### DIFF
--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -529,7 +529,7 @@ export async function setTrialLinks(onSelector = undefined, storeObjBuyLink = un
   const buildUpdatedUrl = async (oldUrl, newUrl, productId, prodUsers, prodYears) => {
     const locale = page.country;
     const oldParams = new URL(oldUrl).searchParams;
-    let campaign = page.getParamValue('vcampaign') || getMetadata('vcampaign') || oldParams.get('COUPON');
+    let campaign = oldParams.get('COUPON');
 
     if (['de', 'nl', 'au', 'gb'].includes(page.country)) campaign = await fetchProductInfo(productId, prodUsers, prodYears, 'coupon');
     const updatedUrl = new URL(newUrl);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://undo-freetrial--www-landing-pages--bitdefender.aem.page/drafts/test-page/