### PR TITLE
fix vlaicu prod mapping

### DIFF
--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -123,6 +123,8 @@ const VALICU_PRODS = {
   vsbm: 'com.bitdefender.vsb',
   sc: 'com.bitdefender.ccp',
   scm: 'com.bitdefender.ccp',
+  idtheftp: 'com.bitdefender.idtheftpremium',
+  idthefts: 'com.bitdefender.idtheftstandard',
 };
 
 /**

--- a/_src-lp/scripts/vendor/product.js
+++ b/_src-lp/scripts/vendor/product.js
@@ -52,6 +52,8 @@ export default class ProductPrice {
     vsbm: "com.bitdefender.vsb",
     sc: "com.bitdefender.ccp",
     scm: "com.bitdefender.ccp",
+    idtheftp: 'com.bitdefender.idtheftpremium',
+    idthefts: 'com.bitdefender.idtheftstandard',
   }
 
   #locale;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://vlaicu-prod-update--www-landing-pages--bitdefender.aem.page/drafts/test-page/