### PR TITLE
DEX-26102 | fix: add triallinks corner case for page loaded event

### DIFF
--- a/_src-lp/scripts/adobeDataLayer.js
+++ b/_src-lp/scripts/adobeDataLayer.js
@@ -182,6 +182,7 @@ export async function sendAnalyticsPageLoadedEvent(force = false) {
     (typeof StoreProducts === 'undefined' && !productsList.length)
     || (typeof StoreProducts !== 'undefined' && StoreProducts.initCount === 0)
     || getMetadata('free-product')
+    || (getMetadata('trialbuylinks') && !getMetadata('allowdatatracking'))
     || force) {
     await target.sendCdpData();
     AdobeDataLayerService.push(new PageLoadedEvent());


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://dex-26102--www-landing-pages--bitdefender.aem.page/drafts/test-page/