### PR TITLE
fix dataset on default links as trial

### DIFF
--- a/_src-lp/scripts/utils.js
+++ b/_src-lp/scripts/utils.js
@@ -610,6 +610,7 @@ export async function setTrialLinks(onSelector = undefined, storeObjBuyLink = un
           // Update hrefs and restore button state
           [...buttonContainerLinks, ...primaryButtonLinks].forEach((btn) => {
             if (btn) {
+              btn.classList.add(`buylink-${productId}-${prodUsers}${Math.floor(prodYears / 12)}`);
               btn.setAttribute('href', updatedUrl);
               btn.style.opacity = '1';
               btn.style.cursor = 'pointer';


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [x] I have updated the sidekick documentation.
- [x] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://trial-update-v2--www-landing-pages--bitdefender.aem.page/drafts/test-page/