### PR TITLE
feat(DEX-27120): added the possibility to load target early for landi…

### DIFF
--- a/_src-lp/scripts/constants.js
+++ b/_src-lp/scripts/constants.js
@@ -39,4 +39,6 @@ export default class Constants {
     'ultsecplusm', 'idtheftsm', 'idtheftpm', 'vsbm', 'scm'];
 
   static DEFAULT_LANGUAGE = 'en';
+
+  static TARGET_EXPERIMENT_METADATA_KEY = 'target-experiment-location';
 }

--- a/_src-lp/scripts/scripts.js
+++ b/_src-lp/scripts/scripts.js
@@ -46,6 +46,7 @@ import {
   fetchGeoIP,
 } from './utils.js';
 import store from './store.js';
+import Constants from './constants.js';
 
 const page = await pagePromise;
 const target = await targetPromise;
@@ -202,6 +203,33 @@ export async function go2Anchor() {
 }
 
 /**
+ * Loads everything that doesn't need to be delayed.
+ * @param {Element} doc The container element
+ */
+
+export async function loadTrackers() {
+  const isPageNotInDraftsFolder = window.location.pathname.indexOf('/drafts/') === -1;
+
+  const onAdobeMcLoaded = () => {
+    document.dispatchEvent(new Event(GLOBAL_EVENTS.ADOBE_MC_LOADED));
+    window.ADOBE_MC_EVENT_LOADED = true;
+  };
+
+  if (isPageNotInDraftsFolder) {
+    try {
+      await Launch.load(page.environment);
+    } catch {
+      target.abort();
+    }
+
+    onAdobeMcLoaded();
+  } else {
+    target.abort();
+    onAdobeMcLoaded();
+  }
+}
+
+/**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
  */
@@ -214,6 +242,12 @@ async function loadEager(doc) {
   if (hasTemplate) {
     loadCSS(`${window.hlx.codeBasePath}/scripts/template-factories/${templateMetadata}/${templateMetadata}.css`);
     addScript(`${window.hlx.codeBasePath}/scripts/template-factories/${templateMetadata}/${templateMetadata}.js`, {}, 'defer', undefined, undefined, 'module');
+  }
+
+  if (getMetadata(Constants.TARGET_EXPERIMENT_METADATA_KEY)) {
+    await loadTrackers();
+    await sendAnalyticsPageEvent();
+    await sendAnalyticsUserInfo();
   }
 
   const main = doc.querySelector('main');
@@ -243,33 +277,6 @@ async function loadEager(doc) {
   }
 }
 
-/**
- * Loads everything that doesn't need to be delayed.
- * @param {Element} doc The container element
- */
-
-export async function loadTrackers() {
-  const isPageNotInDraftsFolder = window.location.pathname.indexOf('/drafts/') === -1;
-
-  const onAdobeMcLoaded = () => {
-    document.dispatchEvent(new Event(GLOBAL_EVENTS.ADOBE_MC_LOADED));
-    window.ADOBE_MC_EVENT_LOADED = true;
-  };
-
-  if (isPageNotInDraftsFolder) {
-    try {
-      await Launch.load(page.environment);
-    } catch {
-      target.abort();
-    }
-
-    onAdobeMcLoaded();
-  } else {
-    target.abort();
-    onAdobeMcLoaded();
-  }
-}
-
 export async function loadLazy(doc) {
   // eslint-disable-next-line import/no-unresolved
   // const fpPromise = import('https://fpjscdn.net/v3/V9XgUXnh11vhRvHZw4dw')
@@ -285,15 +292,16 @@ export async function loadLazy(doc) {
 
   loadHeader(doc.querySelector('header'));
 
-  loadTrackers();
+  if (!getMetadata(Constants.TARGET_EXPERIMENT_METADATA_KEY)) {
+    loadTrackers();
+    await sendAnalyticsPageEvent();
+    await sendAnalyticsUserInfo();
+  }
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({
     'gtm.start': new Date().getTime(),
     event: 'gtm.js',
   });
-
-  await sendAnalyticsPageEvent();
-  await sendAnalyticsUserInfo();
 
   loadFooter(doc.querySelector('footer'));
 


### PR DESCRIPTION
…ng pages

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://dex-27120--www-landing-pages--bitdefender.aem.page/drafts/test-page/