### PR TITLE
DEX-27242 | fix: take product id from each variation

### DIFF
--- a/_src-lp/scripts/vendor/product.js
+++ b/_src-lp/scripts/vendor/product.js
@@ -253,7 +253,7 @@ export default class ProductPrice {
         campaign: this.#campaign,
         campaignType: this.#campaignType,
         locale: this.#locale,
-        platformProductID: payload.platformProductId,
+        platformProductID: option.verifoneProductId || payload.platformProductId,
         variations: {
           [this.#devicesNo]: {
             [this.#yearsNo]: this.#generateVariationObject(payload, option, buy_link)


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://DEX-27242--www-landing-pages--bitdefender.aem.page/drafts/test-page/