### PR TITLE
fix: plans switcher default selection

### DIFF
--- a/_src-lp/blocks/new-prod-boxes/new-prod-boxes.js
+++ b/_src-lp/blocks/new-prod-boxes/new-prod-boxes.js
@@ -161,6 +161,8 @@ export default function decorate(block) {
   let trialLinks = false;
   if (parentSection.classList.contains('trial-links')) trialLinks = true;
 
+  let switchCheckbox;
+
   if (productsAsList.length) {
     productsAsList.forEach((prod) => updateProductsList(prod));
 
@@ -221,10 +223,9 @@ export default function decorate(block) {
       `;
 
       // Get the checkbox inside the switchBox
-      const switchCheckbox = switchBox.querySelector('#switchCheckbox');
+      switchCheckbox = switchBox.querySelector('#switchCheckbox');
 
       // Check if individualSwitchText includes 'reverted'
-      if (individual === 'reverted') switchCheckbox.checked = true;
 
       // Add an event listener to the checkbox
       switchCheckbox.addEventListener('change', () => {
@@ -909,6 +910,11 @@ export default function decorate(block) {
 
   window.addEventListener('resize', updateMargin());
   setTimeout(() => updateMargin(), 0);
+
+  if (switchCheckbox && individual === 'reverted') {
+    switchCheckbox.checked = true;
+    switchCheckbox.dispatchEvent(new Event('change'));
+  }
 
   block.addEventListener('click', (e) => {
     const clickedButton = e.target.closest('.list-toggle');


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Documentation
- [ ] I have updated the sidekick documentation.
- [ ] I have updated new baselines in GhostInspector.

Test URLs:
- Before: https://main--www-landing-pages--bitdefender.aem.page/drafts/test-page/
- After: https://fix-plans-switcher--www-landing-pages--bitdefender.aem.page/drafts/test-page/